### PR TITLE
Only forward Alarms with flag 0xA2, ignore others

### DIFF
--- a/gosenseapp.go
+++ b/gosenseapp.go
@@ -208,7 +208,13 @@ loop:
 		case a := <-alarmch:
 			log.Infof("ALARM: %s, state: %d",
 				a.MAC, a.State)
-
+			// Only Alarms with flag 0xA2 (162) signal an open/close/motion alarm
+			if int(a.SensorFlags) != 162 {
+				log.Infof("ALARM: Ignoring Alarm with unknown flag: %x",
+					  a.SensorFlags)
+				break
+			}
+			
 			SenseData.Lock()
 			sensor, ok := SenseData.AppConfig.Sensors[a.MAC]
 			if ok {


### PR DESCRIPTION
Alarms with flags other than 0xA2 are not well understood nor do they follow the expected format of this repo and therefore should not be sent to MQTT. 
All open/close & motion on/off alarms in my testing have had the SensorFlag 0xA2

I've never written Go before, if there is a better/cleaner way to do this, please edit.

Fixes #2 